### PR TITLE
Handle more edge cases for Delete()

### DIFF
--- a/radix.go
+++ b/radix.go
@@ -275,18 +275,19 @@ DELETE:
 	n.leaf = nil
 	t.size--
 
+	// Check if we should delete this node from the parent
+	if parent != nil && len(n.edges) == 0 {
+		parent.delEdge(label)
+	}
+
 	// Check if we should merge this node
-	if len(n.edges) == 1 {
+	if n != t.root && len(n.edges) == 1 {
 		n.mergeChild()
 	}
 
-	// Check if we should merge or delete this node
-	if parent != nil {
-		if len(n.edges) == 0 {
-			parent.delEdge(label)
-		} else if len(parent.edges) == 1 && !parent.isLeaf() {
-			parent.mergeChild()
-		}
+	// Check if we should merge the parent's other child
+	if parent != nil && parent != t.root && len(parent.edges) == 1 && !parent.isLeaf() {
+		parent.mergeChild()
 	}
 
 	return leaf.val, true

--- a/radix_test.go
+++ b/radix_test.go
@@ -86,6 +86,24 @@ func TestRoot(t *testing.T) {
 	}
 }
 
+func TestDelete(t *testing.T) {
+
+	r := New()
+
+	s := []string{"", "A", "AB"}
+
+	for _, ss := range s {
+		r.Insert(ss, true)
+	}
+
+	for _, ss := range s {
+		_, ok := r.Delete(ss)
+		if !ok {
+			t.Fatalf("bad %q", ss)
+		}
+	}
+}
+
 func TestLongestPrefix(t *testing.T) {
 	r := New()
 


### PR DESCRIPTION
We should never merge into the root node since it's assumed to be the
empty string.

We need to check for deleting this node from the parent before we have
potentially merged the node and its child.  If we check after we've
merged, it might be the case that the merged node has no children (in
which case we don't want to delete it from the parent, since it's still
a valid entry.)

This patch includes tests to check that we're handling these cases.