### PR TITLE
Fix panic when node is deleted while walking

### DIFF
--- a/radix.go
+++ b/radix.go
@@ -515,6 +515,10 @@ func (t *Tree) WalkPath(path string, fn WalkFn) {
 // recursiveWalk is used to do a pre-order walk of a node
 // recursively. Returns true if the walk should be aborted
 func recursiveWalk(n *node, fn WalkFn) bool {
+	if n == nil {
+		return false
+	}
+
 	// Visit the leaf values if any
 	if n.leaf != nil && fn(n.leaf.key, n.leaf.val) {
 		return true


### PR DESCRIPTION
If a node is deleted from within the walk function, currently the recursive walk will panic if it then tries to go down that branch. Instead, terminate walking that branch.