### PR TITLE
V2 Using Go 1.18+ Generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For an immutable variant, see [go-immutable-radix](https://github.com/hashicorp/
 Documentation
 =============
 
-The full documentation is available on [Godoc](http://godoc.org/github.com/armon/go-radix).
+The full documentation is available on [Godoc](http://pkg.go.dev/github.com/armon/go-radix).
 
 Example
 =======
@@ -24,7 +24,7 @@ Below is a simple example of usage
 
 ```go
 // Create a tree
-r := radix.New()
+r := radix.New[int]()
 r.Insert("foo", 1)
 r.Insert("bar", 2)
 r.Insert("foobar", 2)

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/armon/go-radix
+
+go 1.18

--- a/radix_test.go
+++ b/radix_test.go
@@ -68,7 +68,7 @@ func TestRadix(t *testing.T) {
 }
 
 func TestRoot(t *testing.T) {
-	r := New()
+	r := New[bool]()
 	_, ok := r.Delete("")
 	if ok {
 		t.Fatalf("bad")
@@ -89,7 +89,7 @@ func TestRoot(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 
-	r := New()
+	r := New[bool]()
 
 	s := []string{"", "A", "AB"}
 
@@ -122,7 +122,7 @@ func TestDeletePrefix(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		r := New()
+		r := New[bool]()
 		for _, ss := range test.inp {
 			r.Insert(ss, true)
 		}
@@ -133,7 +133,7 @@ func TestDeletePrefix(t *testing.T) {
 		}
 
 		out := []string{}
-		fn := func(s string, v interface{}) bool {
+		fn := func(s string, v bool) bool {
 			out = append(out, s)
 			return false
 		}
@@ -146,7 +146,7 @@ func TestDeletePrefix(t *testing.T) {
 }
 
 func TestLongestPrefix(t *testing.T) {
-	r := New()
+	r := New[interface{}]()
 
 	keys := []string{
 		"",
@@ -194,7 +194,7 @@ func TestLongestPrefix(t *testing.T) {
 }
 
 func TestWalkPrefix(t *testing.T) {
-	r := New()
+	r := New[interface{}]()
 
 	keys := []string{
 		"foobar",
@@ -273,7 +273,7 @@ func TestWalkPrefix(t *testing.T) {
 }
 
 func TestWalkPath(t *testing.T) {
-	r := New()
+	r := New[interface{}]()
 
 	keys := []string{
 		"foo",
@@ -345,7 +345,7 @@ func TestWalkPath(t *testing.T) {
 }
 
 func TestWalkDelete(t *testing.T) {
-	r := New()
+	r := New[interface{}]()
 	r.Insert("init0/0", nil)
 	r.Insert("init0/1", nil)
 	r.Insert("init0/2", nil)
@@ -394,7 +394,7 @@ func generateUUID() string {
 }
 
 func BenchmarkInsert(b *testing.B) {
-	r := New()
+	r := New[bool]()
 	for i := 0; i < 10000; i++ {
 		r.Insert(fmt.Sprintf("init%d", i), true)
 	}


### PR DESCRIPTION
This PR includes no functional changes to the library. Instead its sole purpose is to enable the library to use generics for the values stored within the tree. This has some ergonomic advantages of not requiring type coercions in the consuming code. 

This would be a breaking change and require a v2 version. For users wanting to migrate they can start by replacing calls like `radix.New()` with `radix.New[interface{}]()`. Eventually if they want to also be able to elide type coercions they can change the value type.