### PR TITLE
Fix typo: "exhaution" to "exhaustion" in radix.go comments

### DIFF
--- a/radix.go
+++ b/radix.go
@@ -155,7 +155,7 @@ func (t *Tree) Insert(s string, v interface{}) (interface{}, bool) {
 	n := t.root
 	search := s
 	for {
-		// Handle key exhaution
+		// Handle key exhaustion
 		if len(search) == 0 {
 			if n.isLeaf() {
 				old := n.leaf.val
@@ -246,7 +246,7 @@ func (t *Tree) Delete(s string) (interface{}, bool) {
 	n := t.root
 	search := s
 	for {
-		// Check for key exhaution
+		// Check for key exhaustion
 		if len(search) == 0 {
 			if !n.isLeaf() {
 				break
@@ -356,7 +356,7 @@ func (t *Tree) Get(s string) (interface{}, bool) {
 	n := t.root
 	search := s
 	for {
-		// Check for key exhaution
+		// Check for key exhaustion
 		if len(search) == 0 {
 			if n.isLeaf() {
 				return n.leaf.val, true
@@ -392,7 +392,7 @@ func (t *Tree) LongestPrefix(s string) (string, interface{}, bool) {
 			last = n.leaf
 		}
 
-		// Check for key exhaution
+		// Check for key exhaustion
 		if len(search) == 0 {
 			break
 		}
@@ -496,7 +496,7 @@ func (t *Tree) WalkPath(path string, fn WalkFn) {
 			return
 		}
 
-		// Check for key exhaution
+		// Check for key exhaustion
 		if len(search) == 0 {
 			return
 		}


### PR DESCRIPTION
This pull request includes minor changes to the `radix.go` file. The changes correct a typo in the comments across several functions. The word "exhaution" has been corrected to "exhaustion".

The changes were made in the following functions:

* `Insert(s string, v interface{}) (interface{}, bool)`: Corrected the comment "Handle key exhaution" to "Handle key exhaustion".
* `Delete(s string) (interface{}, bool)`: Corrected the comment "Check for key exhaution" to "Check for key exhaustion".
* `Get(s string) (interface{}, bool)`: Corrected the comment "Check for key exhaution" to "Check for key exhaustion".
* `LongestPrefix(s string) (string, interface{}, bool)`: Corrected the comment "Check for key exhaution" to "Check for key exhaustion".
* `WalkPath(path string, fn WalkFn)`: Corrected the comment "Check for key exhaution" to "Check for key exhaustion".